### PR TITLE
Feature/add visible boundaries to the scene for the ball and player

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -167,6 +167,7 @@ GameObject:
   - component: {fileID: 235705504}
   - component: {fileID: 235705505}
   - component: {fileID: 235705506}
+  - component: {fileID: 235705507}
   m_Layer: 0
   m_Name: Bottom
   m_TagString: Untagged
@@ -286,6 +287,19 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &235705507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 235705503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1eb0cad6b7995894282772551d9c895a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isTop: 0
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -391,6 +405,7 @@ GameObject:
   - component: {fileID: 1546606520}
   - component: {fileID: 1546606521}
   - component: {fileID: 1546606522}
+  - component: {fileID: 1546606523}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -459,8 +474,8 @@ Transform:
   m_GameObject: {fileID: 1546606517}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -8.5488, y: 0, z: 0}
-  m_LocalScale: {x: 0.5424, y: 2.949776, z: 1}
+  m_LocalPosition: {x: -8.612, y: 0, z: 0}
+  m_LocalScale: {x: 0.5424, y: 2.212332, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -553,6 +568,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 10
+  boundary: {fileID: 1684387074}
+--- !u!50 &1546606523
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1546606517}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
 --- !u!1 &1684387074
 GameObject:
   m_ObjectHideFlags: 0
@@ -564,6 +607,7 @@ GameObject:
   - component: {fileID: 1684387075}
   - component: {fileID: 1684387076}
   - component: {fileID: 1684387077}
+  - component: {fileID: 1684387078}
   m_Layer: 0
   m_Name: Top
   m_TagString: Untagged
@@ -683,6 +727,19 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &1684387078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684387074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1eb0cad6b7995894282772551d9c895a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isTop: 1
 --- !u!1 &1869167799
 GameObject:
   m_ObjectHideFlags: 0
@@ -694,6 +751,7 @@ GameObject:
   - component: {fileID: 1869167802}
   - component: {fileID: 1869167801}
   - component: {fileID: 1869167800}
+  - component: {fileID: 1869167803}
   m_Layer: 0
   m_Name: Ball
   m_TagString: Untagged
@@ -803,6 +861,33 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &1869167803
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869167799}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -7,6 +7,7 @@ using UnityEngine.InputSystem;
 public class PlayerMovement : MonoBehaviour
 {
     [SerializeField] float moveSpeed = 10f;
+    [SerializeField] GameObject boundary;
 
     Vector2 playerInput;
     Vector2 minBounds;
@@ -31,6 +32,8 @@ public class PlayerMovement : MonoBehaviour
     void MovePlayer()
     {
         float yPadding = transform.localScale.y / 2;
+        yPadding += boundary.transform.localScale.y;
+
         Vector2 playerDir = playerInput * moveSpeed * Time.deltaTime;
         Vector2 newPos = new Vector2();
         newPos.y = Mathf.Clamp(transform.position.y + playerDir.y, minBounds.y + yPadding, maxBounds.y - yPadding);

--- a/Assets/Scripts/SetupBoundaries.cs
+++ b/Assets/Scripts/SetupBoundaries.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetupBoundaries : MonoBehaviour
+{
+    [SerializeField] bool isTop;
+
+    float padding;
+
+    Vector2 yBounds;
+    void Start()
+    {
+        padding = transform.localScale.y;
+        transform.localScale = new Vector2(Screen.width, padding);
+
+        if (isTop)
+        {
+            yBounds = Camera.main.ViewportToWorldPoint(new Vector2(1, 1));
+            Vector2 newPos = new Vector2(0, yBounds.y - padding);
+        }
+        else
+        {
+            yBounds = Camera.main.ViewportToWorldPoint(new Vector2(0, 0));
+            Vector2 newPos = new Vector2(0, yBounds.y + padding);
+        }
+    }
+}

--- a/Assets/Scripts/SetupBoundaries.cs.meta
+++ b/Assets/Scripts/SetupBoundaries.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1eb0cad6b7995894282772551d9c895a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implemented the following with this PR:
- Added the sprites for the play area boundaries with colliders.
- Added code to ensure the boundaries are always at the top and bottom of the scene as well as the right width for the screen.